### PR TITLE
Fix volume info by discarding node volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,237 @@ make publish-test-results
 ```
 kubectl logs -l app=metrisv2 -n kcp-system -c metrisv2 -f
 ```
+
+#### Data collection
+
+Metris collects information about billable hyperscaler usage and sends it to EDP. This data has to adhere to the following schema:
+
+```json
+{
+  "name": "consumption-metrics",
+  "jsonSchema": {
+    "type": "object",
+    "title": "SKR Metering Schema",
+    "description": "SKR Metering Schema.",
+    "required": [
+      "timestamp",
+      "compute",
+      "networking"
+    ],
+    "properties": {
+      "timestamp": {
+        "$id": "#/properties/timestamp",
+        "type": "string",
+        "format": "date-time",
+        "title": "The Timestamp Schema",
+        "description": "Event Creation Timestamp",
+        "default": "",
+        "examples": ["2020-03-25T09:16:41+00:00"]
+      },
+      "compute": {
+        "$id": "#/properties/compute",
+        "type": "object",
+        "title": "The Compute Schema",
+        "description": "Contains Azure Compute metrics",
+        "default": {},
+        "examples": [
+          {
+            "provisioned_cpus": 24.0,
+            "provisioned_volumes": {
+              "size_gb_rounded": 192.0,
+              "count": 3.0,
+              "size_gb_total": 150.0
+            },
+            "vm_types": [
+              {
+                "name": "Standard_D8_v3",
+                "count": 3.0
+              },
+              {
+                "name": "Standard_D6_v3",
+                "count": 2.0
+              }
+            ],
+            "provisioned_ram_gb": 96.0
+          }
+        ],
+        "required": [
+          "vm_types",
+          "provisioned_cpus",
+          "provisioned_ram_gb",
+          "provisioned_volumes"
+        ],
+        "properties": {
+          "vm_types": {
+            "$id": "#/properties/compute/properties/vm_types",
+            "type": "array",
+            "title": "The Vm_types Schema",
+            "description": "A list of VM types that have been used for this SKR instance.",
+            "default": [],
+            "items": {
+              "$id": "#/properties/compute/properties/vm_types/items",
+              "type": "object",
+              "title": "The Items Schema",
+              "description": "The Azure instance type name and the provisioned quantity at the time of the event.",
+              "default": {},
+              "examples": [
+                {
+                  "name": "Standard_D8_v3",
+                  "count": 3.0
+                },
+                {
+                  "name": "Standard_D6_v3",
+                  "count": 2.0
+                }
+              ],
+              "required": ["name", "count"],
+              "properties": {
+                "name": {
+                  "$id": "#/properties/compute/properties/vm_types/items/properties/name",
+                  "type": "string",
+                  "title": "The Name Schema",
+                  "description": "Name of the instance type",
+                  "default": "",
+                  "examples": ["Standard_D8_v3"]
+                },
+                "count": {
+                  "$id": "#/properties/compute/properties/vm_types/items/properties/count",
+                  "type": "integer",
+                  "title": "The Count Schema",
+                  "description": "Quantity of the instances",
+                  "default": 0,
+                  "examples": [3]
+                }
+              }
+            }
+          },
+          "provisioned_cpus": {
+            "$id": "#/properties/compute/properties/provisioned_cpus",
+            "type": "integer",
+            "title": "The Provisioned_cpus Schema",
+            "description": "The total sum of all CPUs provisioned from all instances (number of instances *  number of CPUs per instance)",
+            "default": 0,
+            "examples": [24]
+          },
+          "provisioned_ram_gb": {
+            "$id": "#/properties/compute/properties/provisioned_ram_gb",
+            "type": "integer",
+            "title": "The Provisioned_ram_gb Schema",
+            "description": "The total sum of Memory (RAM) of all provisioned instances (number of instances * number of GB RAM per instance).",
+            "default": 0,
+            "examples": [96]
+          },
+          "provisioned_volumes": {
+            "$id": "#/properties/compute/properties/provisioned_volumes",
+            "type": "object",
+            "title": "The Provisioned_volumes Schema",
+            "description": "Volumes (Disk) provisioned(excluding the Node volumes).",
+            "default": {},
+            "examples": [
+              {
+                "size_gb_rounded": 192.0,
+                "count": 3.0,
+                "size_gb_total": 150.0
+              }
+            ],
+            "required": ["size_gb_total", "count", "size_gb_rounded"],
+            "properties": {
+              "size_gb_total": {
+                "$id": "#/properties/compute/properties/provisioned_volumes/properties/size_gb_total",
+                "type": "integer",
+                "title": "The Size_gb_total Schema",
+                "description": "The total GB disk space requested by a kyma instance",
+                "default": 0,
+                "examples": [150]
+              },
+              "count": {
+                "$id": "#/properties/compute/properties/provisioned_volumes/properties/count",
+                "type": "integer",
+                "title": "The Count Schema",
+                "description": "The number of disks provisioned.",
+                "default": 0,
+                "examples": [3]
+              },
+              "size_gb_rounded": {
+                "$id": "#/properties/compute/properties/provisioned_volumes/properties/size_gb_rounded",
+                "type": "integer",
+                "title": "The Size_gb_rounded Schema",
+                "description": "Azure charges disk in 32GB blocks. If one provisions e.g. 16GB, he still pays 32 GB. This value here is rounding up each volume to the next y 32 dividable number and sums these values up.",
+                "default": 0,
+                "examples": [192]
+              }
+            }
+          }
+        }
+      },
+      "networking": {
+        "$id": "#/properties/networking",
+        "type": "object",
+        "title": "The Networking Schema",
+        "description": "Some networking controlling data.",
+        "default": {},
+        "examples": [
+          {
+            "provisioned_vnets": 2.0,
+            "provisioned_ips": 3.0
+          }
+        ],
+        "required": [
+          "provisioned_vnets",
+          "provisioned_ips"
+        ],
+        "properties": {
+          "provisioned_vnets": {
+            "$id": "#/properties/networking/properties/provisioned_vnets",
+            "type": "integer",
+            "title": "The Provisioned_vnets Schema",
+            "description": "Number of virtual networks",
+            "default": 0,
+            "examples": [2]
+          },
+          "provisioned_ips": {
+            "$id": "#/properties/networking/properties/provisioned_ips",
+            "type": "integer",
+            "title": "The Provisioned_ips Schema",
+            "description": "Number of IPs",
+            "default": 0,
+            "examples": [3]
+          }
+        }
+      }
+    }
+  },
+  "version": "1",
+  "eventTimeField": "event.timestamp"
+}
+```
+
+See the example of data sent to EDP:
+
+```json
+{
+  "compute": {
+    "vm_types": [
+      {
+        "name": "Standard_D8_v3",
+        "count": 3
+      },
+      {
+        "name": "Standard_D6_v3",
+        "count": 2
+      }
+    ],
+    "provisioned_cpus": 24,  
+    "provisioned_ram_gb": 96,
+    "provisioned_volumes": {
+      "size_gb_total": 150,
+      "count": 3,
+      "size_gb_rounded": 192
+    }
+  },
+  "networking": {
+    "provisioned_vnets": 2,
+    "provisioned_ips": 3
+  }
+}
+```

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -111,7 +111,6 @@ func main() {
 	if opts.DebugPort > 0 {
 		enableDebugging(opts.DebugPort, log)
 	}
-	// Start a server to cater to the metrics and healthz endpoints
 	router := mux.NewRouter()
 	router.Path(healthzPath).HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		writer.WriteHeader(http.StatusOK)
@@ -124,6 +123,7 @@ func main() {
 		Router: router,
 	}
 
+	// Start a server to cater to the metrics and healthz endpoints
 	metrisSvr.Start()
 }
 

--- a/dev/deployment.yaml
+++ b/dev/deployment.yaml
@@ -21,6 +21,8 @@ spec:
     metadata:
       labels:
         app: metrisv2
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - image: ko://github.com/kyma-incubator/metris/cmd

--- a/dev/deployment.yaml
+++ b/dev/deployment.yaml
@@ -62,8 +62,11 @@ spec:
         - containerPort: 8080
           name: http
           protocol: TCP
-
-        ## readiness and liveness probe
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+          initialDelaySeconds: 10
       restartPolicy: Always
       schedulerName: default-scheduler
       terminationGracePeriodSeconds: 30

--- a/pkg/edp/client.go
+++ b/pkg/edp/client.go
@@ -51,7 +51,6 @@ func (eClient Client) NewRequest(dataTenant string) (*http.Request, error) {
 		eClient.Config.DataStreamEnv,
 	)
 
-	eClient.Logger.Debugf("sending event to '%s'", edpURL)
 	req, err := http.NewRequest(http.MethodPost, edpURL, bytes.NewBuffer([]byte{}))
 	if err != nil {
 		return nil, fmt.Errorf("failed generate request for EDP, %d: %v", http.StatusBadRequest, err)
@@ -105,6 +104,6 @@ func (eClient Client) Send(req *http.Request, payload []byte) (*http.Response, e
 			eClient.Logger.Warn(err)
 		}
 	}()
-
+	eClient.Logger.Debugf("sent an event to '%s' with eventstream: '%s'", req.URL.String(), string(payload))
 	return resp, nil
 }

--- a/pkg/process/event_stream.go
+++ b/pkg/process/event_stream.go
@@ -59,8 +59,8 @@ func (inp Input) Parse(providers *Providers) (*edp.ConsumptionMetrics, error) {
 	providerType := inp.shoot.Spec.Provider.Type
 	vmTypes := make(map[string]int)
 
-	nodeStorage := int64(0)
 	pvcStorage := int64(0)
+	pvcStorageRounded := int64(0)
 	volumeCount := 0
 	vnets := 0
 
@@ -77,10 +77,6 @@ func (inp Input) Parse(providers *Providers) (*edp.ConsumptionMetrics, error) {
 		provisionedMemory += vmFeatures.Memory
 		vmTypes[nodeType] += 1
 
-		// Calculate node storage
-		nodeStorage += vmFeatures.Storage
-		volumeCount += 1
-
 	}
 
 	if inp.pvcList != nil {
@@ -89,6 +85,7 @@ func (inp Input) Parse(providers *Providers) (*edp.ConsumptionMetrics, error) {
 			if pvc.Status.Phase == corev1.ClaimBound {
 				currPVC := getSizeInGB(pvc.Status.Capacity.Storage())
 				pvcStorage += currPVC
+				pvcStorageRounded += getVolumeRoundedToFactor(currPVC)
 				volumeCount += 1
 			}
 		}
@@ -128,9 +125,8 @@ func (inp Input) Parse(providers *Providers) (*edp.ConsumptionMetrics, error) {
 	metric.Compute.ProvisionedCpus = provisionedCPUs
 	metric.Compute.ProvisionedRAMGb = provisionedMemory
 
-	totalActualStorage := nodeStorage + pvcStorage
-	metric.Compute.ProvisionedVolumes.SizeGbTotal = totalActualStorage
-	metric.Compute.ProvisionedVolumes.SizeGbRounded = getVolumeRoundedToFactor(totalActualStorage)
+	metric.Compute.ProvisionedVolumes.SizeGbTotal = pvcStorage
+	metric.Compute.ProvisionedVolumes.SizeGbRounded = pvcStorageRounded
 	metric.Compute.ProvisionedVolumes.Count = volumeCount
 
 	metric.Networking.ProvisionedIPs = provisionedIPs

--- a/pkg/process/event_stream_test.go
+++ b/pkg/process/event_stream_test.go
@@ -46,9 +46,9 @@ func TestParse(t *testing.T) {
 					ProvisionedCpus:  16,
 					ProvisionedRAMGb: 64,
 					ProvisionedVolumes: edp.ProvisionedVolumes{
-						SizeGbTotal:   435,
-						Count:         5,
-						SizeGbRounded: 448,
+						SizeGbTotal:   35,
+						Count:         3,
+						SizeGbRounded: 96,
 					},
 				},
 				Networking: edp.Networking{
@@ -74,9 +74,9 @@ func TestParse(t *testing.T) {
 					ProvisionedCpus:  24,
 					ProvisionedRAMGb: 96,
 					ProvisionedVolumes: edp.ProvisionedVolumes{
-						SizeGbTotal:   600,
-						Count:         3,
-						SizeGbRounded: 608,
+						SizeGbTotal:   0,
+						Count:         0,
+						SizeGbRounded: 0,
 					},
 				},
 				Networking: edp.Networking{
@@ -101,9 +101,9 @@ func TestParse(t *testing.T) {
 					ProvisionedCpus:  24,
 					ProvisionedRAMGb: 96,
 					ProvisionedVolumes: edp.ProvisionedVolumes{
-						SizeGbTotal:   600,
-						Count:         3,
-						SizeGbRounded: 608,
+						SizeGbTotal:   0,
+						Count:         0,
+						SizeGbRounded: 0,
 					},
 				},
 				Networking: edp.Networking{

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -264,7 +264,6 @@ func (p *Process) execute(identifier int) {
 		if !isOldMetricValid {
 			p.Cache.Set(record.SubAccountID, *record, cache.NoExpiration)
 			p.Logger.Debugf("[worker: %d] successfully saved metric for subAccountID %s", identifier, record.SubAccountID)
-			p.Logger.Infof("[worker: %d] successfully saved metric for subAccountID %s", identifier, record.SubAccountID)
 		}
 
 		// Requeue the subAccountID anyway

--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -536,9 +536,9 @@ func NewMetric() *edp.ConsumptionMetrics {
 			ProvisionedCpus:  24,
 			ProvisionedRAMGb: 96,
 			ProvisionedVolumes: edp.ProvisionedVolumes{
-				SizeGbTotal:   630,
-				Count:         5,
-				SizeGbRounded: 640,
+				SizeGbTotal:   30,
+				Count:         2,
+				SizeGbRounded: 64,
 			},
 		},
 		Networking: edp.Networking{


### PR DESCRIPTION
Reasons:
- Node volumes should not considered in `size_gb_rounded` and `size_gb_total`
- `size_gb_rounded` is the sum of each volumes(PVs) rounded to 32